### PR TITLE
(cen-abcd) Correct Star Trek - Battlestar references

### DIFF
--- a/FTLdrive-instructions.txt
+++ b/FTLdrive-instructions.txt
@@ -1,1 +1,3 @@
-Call Scotty
+Call Scotty.
+
+Star Trek doesn't call it FTL.

--- a/wastedspace.txt
+++ b/wastedspace.txt
@@ -1,0 +1,1 @@
+cen was here


### PR DESCRIPTION
Scotty maintained warp drives.  FTL drives are in the new Battlestar
Galactica and a variety of other more recent science fiction.