### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Add the output of this (your SSH public key) to Github under "Account Settings" 
 Fork the other project to your own Github account and clone to work with locally
 <pre>
   git clone git@github.com:YOUR_GITHUB_NAME/learngit.git
-  git remote -v
   cd learngit/
+  git remote -v
 </pre>
 
 Add a git remote for the upstream repository


### PR DESCRIPTION
git remote -v came before cd learngit/ in the original  README.md, so I
fixed it, this will allow future classed to do the proper steps
correctly